### PR TITLE
Fix black background with transparent theme

### DIFF
--- a/lua/twilight/config.lua
+++ b/lua/twilight/config.lua
@@ -7,6 +7,7 @@ local defaults = {
     alpha = 0.25, -- amount of dimming
     -- we try to get the foreground from the highlight groups or fallback color
     color = { "Normal", "#ffffff" },
+    term_bg = "#000000", -- if guibg=NONE, this will be used to calculate text color
     inactive = false, -- when true, other windows will be fully dimmed (unless they contain the same buffer)
   },
   context = 10, -- amount of lines we will try to show arounc the current line
@@ -48,12 +49,12 @@ function M.colors()
     end
   end
   local normal = util.get_hl("Normal")
-  local bg = "#000000" -- fallback to black for bg
-	if normal then 
-	  bg = normal.background or "NONE"
-	end
-  -- use black in blend function if background is NONE
-  local bg_hex = (bg ~= "NONE") and bg or "#000000"
+  local bg = M.options.dimming.term_bg
+  if normal then 
+    bg = normal.background or "NONE"
+  end
+  -- use terminal background in blend function if guibg is NONE
+  local bg_hex = (bg ~= "NONE") and bg or M.options.dimming.term_bg
   local dimmed = util.blend(fg, bg_hex, M.options.dimming.alpha)
   vim.cmd("highlight! def Twilight guifg=" .. dimmed .. " guibg=" .. bg)
 end

--- a/lua/twilight/config.lua
+++ b/lua/twilight/config.lua
@@ -48,8 +48,13 @@ function M.colors()
     end
   end
   local normal = util.get_hl("Normal")
-  local bg = (normal and normal.background) or "#000000"
-  local dimmed = util.blend(fg, bg, M.options.dimming.alpha)
+  local bg = "#000000" -- fallback to black for bg
+	if normal then 
+	  bg = normal.background or "NONE"
+	end
+  -- use black in blend function if background is NONE
+  local bg_hex = (bg ~= "NONE") and bg or "#000000"
+  local dimmed = util.blend(fg, bg_hex, M.options.dimming.alpha)
   vim.cmd("highlight! def Twilight guifg=" .. dimmed .. " guibg=" .. bg)
 end
 


### PR DESCRIPTION
Fixes #15
Adds a flag `dimming.term_bg` to setup() - used as bg color for blending if the background is transparent (as well as fallback if get_hl("Normal") returns nil).