### PR TITLE
Update README.md link name to `lazy.nvim` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pairs well with [zen-mode](https://github.com/folke/zen-mode.nvim).
 
 Install the plugin with your preferred package manager:
 
-### [folke](https://github.com/folke/lazy.nvim)
+### [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
 -- Lua


### PR DESCRIPTION
When reading the README I thought `folke` was yet another plugin manager :smile: 